### PR TITLE
useMouseFollower 훅

### DIFF
--- a/docs/docs/hooks/useMouseFollower.md
+++ b/docs/docs/hooks/useMouseFollower.md
@@ -1,0 +1,217 @@
+# useMouseFollower
+
+`useMouseFollower`는 DOM 요소를 마우스 포인터처럼 따라다니게 만들어주는 커스텀 React Hook입니다.
+
+커스텀 커서를 만들어 **기존 포인터(global cursor)를 대체**하거나, 특정 영역 안에서만 표시되는 **존 커서(zone cursor)** 를 구현할 수 있습니다.
+
+**존/글로벌 간 활성 상태를 자동으로 동기화** 해줍니다.
+내부적으로는 전역 store를 두고, 하나 이상의 존 커서가 활성화되면 글로벌 커서는 자동으로 숨겨지는 방식으로 동작합니다.
+
+DOM 요소의 `transform: translate3d(x, y, 0)` 스타일을 직접 갱신하므로, 별도의 state 업데이트 없이 리렌더링 없이 부드럽게 움직입니다.
+
+---
+
+## 🔗 사용법
+
+전체 영역에서 사용하는 **글로벌 커서(global cursor)**
+
+```tsx
+const cursorRef = useMouseFollower<HTMLDivElement>();
+```
+
+또는 특정 DOM 영역 안에서만 보이는 **존 커서(zone cursor)**
+
+```tsx
+const zoneRef = useRef<HTMLDivElement>(null);
+const cursorRef = useMouseFollower<HTMLDivElement, HTMLDivElement>({ targetRef: zoneRef });
+```
+
+---
+
+## 매개변수
+
+```tsx
+type useMouseFollowerOptions<T extends HTMLElement = HTMLElement> = {
+  targetRef?: React.RefObject<T | null>;
+  style?: {
+    /** 포인터 상대 오프셋(px). 기본 { x: 0, y: 0 } */
+    offset?: { x?: number; y?: number };
+  };
+};
+```
+
+| 키               | 타입                        | 기본값      | 설명                                                |
+| ---------------- | --------------------------- | ----------- | --------------------------------------------------- |
+| `targetRef`      | `RefObject<T> \| undefined` | `undefined` | 커서가 표시될 특정 영역의 ref. 없으면 글로벌로 동작 |
+| `style.offset.x` | `number \| undefined`       | `0`         | 포인터 X 좌표에서의 픽셀 오프셋                     |
+| `style.offset.y` | `number \| undefined`       | `0`         | 포인터 Y 좌표에서의 픽셀 오프셋                     |
+
+> 예: 텍스트/이미지 커서를 포인터 중앙에 맞추고 싶을 때 offset으로 미세 조정하세요. (중심 정렬은 아래 “커스터마이즈 팁” 참고)
+
+---
+
+### 반환값
+
+`React.RefObject<E | null>`
+
+- 커서로 사용할 DOM 요소에 연결해야 하는 `ref` 객체
+
+---
+
+### 제네릭 타입
+
+- `E`: 커서(팔로워) 요소 타입 (기본 `HTMLElement`)
+- `T`: 타깃(존) 요소 타입 (기본 `HTMLElement`)
+
+예시:
+
+```tsx
+// 커서(E)는 span, 존(T)은 div
+const cursorRef = useMouseFollower<HTMLSpanElement, HTMLDivElement>({ targetRef: zoneRef });
+```
+
+---
+
+## 기본 스타일(자동 적용)
+
+훅은 최초 마운트 시 커서 요소에 다음 **베이스 스타일을 자동 적용**합니다. (좌표계 고정 + 성능 최적화 + 초기 숨김)
+
+```css
+position: fixed;
+top: 0;
+left: 0;
+pointer-events: none;
+will-change: transform, opacity;
+transform: translate3d(-9999px, -9999px, 0); /* 초기 화면 밖 */
+```
+
+> 덕분에 별도 CSS 없이도 바로 사용 가능합니다.
+>
+> 필요 시 추가 스타일(예: `z-index`, `filter`, `mix-blend-mode`)을 커서 요소에 자유롭게 더해도 됩니다.
+
+---
+
+## ✅ 예시
+
+### 기본 사용 - 글로벌 커서(global cursor)
+
+```tsx
+function GlobalCursor() {
+  const cursorRef = useMouseFollower<HTMLDivElement>();
+
+  return (
+    <div
+      ref={cursorRef}
+      style={{
+        position: 'fixed',
+        pointerEvents: 'none',
+        transform: 'translate3d(-9999px, -9999px, 0)',
+      }}
+    >
+      🎯
+    </div>
+  );
+}
+```
+
+### 특정 영역 안 - 존 커서(zone cursor)
+
+```tsx
+function ZoneCursor() {
+  const zoneRef = useRef<HTMLDivElement>(null);
+  const cursorRef = useMouseFollower<HTMLDivElement, HTMLDivElement>({ targetRef: zoneRef });
+
+  return (
+    <div>
+      <divref={zoneRef}
+        style={{ width: 300, height: 300, background: 'lightblue' }}
+      >
+        이 영역 안에서만 보이는 커서
+      </div>
+      <divref={cursorRef}
+        style={{
+          position: 'fixed',
+          pointerEvents: 'none',
+          transform: 'translate3d(-9999px, -9999px, 0)',
+        }}
+      >
+        ✨
+      </div>
+    </div>
+  );
+}
+
+```
+
+### 동시에 동작 (글로벌 + 존)
+
+```tsx
+function CombinedCursorExample() {
+  const zoneRef = useRef<HTMLDivElement>(null);
+
+  const zoneCursorRef = useMouseFollower<HTMLDivElement, HTMLDivElement>({
+    targetRef: zoneRef,
+    style: { offset: { x: 0, y: 0 } },
+  });
+
+  const globalCursorRef = useMouseFollower<HTMLDivElement>({
+    style: { offset: { x: 12, y: 12 } },
+  });
+
+  return (
+    <div>
+      <h1>마우스 따라다니는 커서 예제</h1>
+      <div ref={zoneRef} style={{ width: 300, height: 300, background: 'pink', marginTop: 20 }}>
+        여기에 들어가면 존 커서 활성화
+      </div>
+
+      {/* 존 커서 */}
+      <div ref={zoneCursorRef} style={{ zIndex: 10000 }}>
+        🔵 zone
+      </div>
+
+      {/* 글로벌 커서 (존이 활성화되면 자동 숨김) */}
+      <div ref={globalCursorRef} style={{ zIndex: 9999 }}>
+        ⚪ global
+      </div>
+    </div>
+  );
+}
+```
+
+---
+
+## 💡 만약 이 훅이 없다면?
+
+직접 `pointermove` 이벤트를 등록하고, `clientX/clientY` 좌표를 추적해 DOM 요소의 스타일을 갱신해야 합니다.
+
+또 존 커서를 구현하려면 `getBoundingClientRect`로 inside/outside 여부를 계산하고, **글로벌 커서와 동기화하는 로직까지 직접 작성**해야 합니다.
+
+```tsx
+function ManualCursor() {
+  const cursorRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const el = cursorRef.current;
+    if (!el) return;
+
+    const onMove = (e: PointerEvent) => {
+      el.style.transform = `translate3d(${e.clientX}px, ${e.clientY}px, 0)`;
+    };
+
+    window.addEventListener('pointermove', onMove, { passive: true });
+    return () => window.removeEventListener('pointermove', onMove);
+  }, []);
+
+  return (
+    <divref={cursorRef}
+      style={{ position: 'fixed', pointerEvents: 'none' }}
+    >
+      👆
+    </div>
+  );
+}
+
+```
+
+`useMouseFollower`를 사용하면 이 과정을 훨씬 간단하게 추상화하여 사용할 수 있습니다.

--- a/packages/hooks/src/libs/useMouseFollower.spec.tsx
+++ b/packages/hooks/src/libs/useMouseFollower.spec.tsx
@@ -1,0 +1,138 @@
+import { renderHook, render } from '@testing-library/react';
+import { useRef } from 'react';
+import { useMouseFollower } from './useMouseFollower';
+
+describe('useMouseFollower 훅', () => {
+  it('글로벌 커서: 마우스 이동 시 transform이 업데이트 되어야 한다.', () => {
+    const { result } = renderHook(() => useMouseFollower<HTMLDivElement>());
+    const { current: cursorRef } = result;
+
+    render(<div ref={cursorRef}>마우스 테스트</div>);
+
+    const cursorEl = cursorRef;
+    expect(cursorEl.current).not.toBeNull();
+
+    const evt = new MouseEvent('pointermove', { clientX: 100, clientY: 200, bubbles: true });
+    window.dispatchEvent(evt);
+    expect(cursorEl.current!.style.transform).toBe('translate3d(100px, 200px, 0)');
+  });
+
+  it('존 커서: 영역 안에서는 opacity=1, 밖에서는 0', () => {
+    const Zone = () => {
+      const zoneRef = useRef<HTMLDivElement>(null);
+      const cursorRef = useMouseFollower<HTMLDivElement, HTMLDivElement>({ targetRef: zoneRef });
+      return (
+        <>
+          <div ref={zoneRef} data-testid="zone" style={{ width: 200, height: 200 }} />
+          <div ref={cursorRef} data-testid="cursor" />
+        </>
+      );
+    };
+
+    const { getByTestId } = render(<Zone />);
+    const zone = getByTestId('zone') as HTMLDivElement;
+    const cursor = getByTestId('cursor') as HTMLDivElement;
+
+    // zone의 위치/크기 mock
+    jest.spyOn(zone, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    const zoneInnerEvent = new MouseEvent('pointermove', { clientX: 100, clientY: 100, bubbles: true });
+    window.dispatchEvent(zoneInnerEvent);
+    expect(cursor.style.opacity).toBe('1');
+
+    const zoneOuterEvent = new MouseEvent('pointermove', { clientX: 300, clientY: 300, bubbles: true });
+    window.dispatchEvent(zoneOuterEvent);
+    expect(cursor.style.opacity).toBe('0');
+  });
+
+  it('존 커서는 안/밖에 따라 opacity가 토글된다', () => {
+    const { getByTestId } = render(<App />);
+    const zone = getByTestId('zone') as HTMLDivElement;
+    const zoneCursor = getByTestId('cursor-zone') as HTMLDivElement;
+
+    // zone의 위치/크기 mock
+    jest.spyOn(zone, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    // zone 내부 → opacity=1
+    const zoneInnerEvent = new MouseEvent('pointermove', { clientX: 100, clientY: 100, bubbles: true });
+    window.dispatchEvent(zoneInnerEvent);
+    expect(zoneCursor.style.opacity).toBe('1');
+
+    // zone 외부 → opacity=0
+    const zoneOuterEvent = new MouseEvent('pointermove', { clientX: 300, clientY: 300, bubbles: true });
+    window.dispatchEvent(zoneOuterEvent);
+    expect(zoneCursor.style.opacity).toBe('0');
+  });
+
+  it('글로벌 커서는 존 안에서 숨겨지고, 존 밖에서 보인다', () => {
+    const { getByTestId } = render(<App />);
+    const zone = getByTestId('zone') as HTMLDivElement;
+    const globalCursor = getByTestId('cursor-global') as HTMLDivElement;
+
+    // zone mock
+    jest.spyOn(zone, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 200,
+      bottom: 200,
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    // 존 내부 → 글로벌 커서 숨김
+    const zoneInnerEvent = new MouseEvent('pointermove', { clientX: 100, clientY: 100, bubbles: true });
+    window.dispatchEvent(zoneInnerEvent);
+    expect(globalCursor.style.opacity).toBe('0');
+
+    // 존 외부 → 글로벌 커서 다시 보임
+    const zoneOuterEvent = new MouseEvent('pointermove', { clientX: 300, clientY: 300, bubbles: true });
+    window.dispatchEvent(zoneOuterEvent);
+    expect(globalCursor.style.opacity).toBe('1');
+  });
+});
+
+// 최소 CustomCursor 컴포넌트
+function CustomCursor({ text, targetRef }: { text: string; targetRef?: React.RefObject<HTMLElement | null> }) {
+  const cursorRef = useMouseFollower<HTMLDivElement>({ targetRef });
+  return (
+    <div ref={cursorRef} data-testid={`cursor-${text}`} style={{ position: 'fixed', pointerEvents: 'none' }}>
+      {text}
+    </div>
+  );
+}
+
+// 간단 App: 존 하나 + 글로벌 하나
+function App() {
+  const zoneRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div>
+      <div ref={zoneRef} data-testid="zone" style={{ width: 200, height: 200, background: 'red' }} />
+      <CustomCursor text="zone" targetRef={zoneRef} />
+      <CustomCursor text="global" />
+    </div>
+  );
+}

--- a/packages/hooks/src/libs/useMouseFollower.ts
+++ b/packages/hooks/src/libs/useMouseFollower.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+// zone cursor와 global cursor 의 역할 이해
+
+/**
+ * cursorStore — 전역 커서 가시성 조정을 위한 store
+ *
+ * - 하나 이상의 "존 커서(zone cursor)"가 활성화되면 activeCount > 0
+ * - 글로벌 커서(global cursor)는 이를 구독하여, 활성 존이 있으면 숨김(opacity 0), 없으면 표시(opacity 1)
+ *
+ * 내부 상태를 클로저로 은닉하는 IIFE 형태의 작은 pub/sub 스토어입니다.
+ */
+const cursorStore = (() => {
+  let activeCount = 0;
+  const subscribers = new Set<(isActiveZone: boolean) => void>();
+
+  const notify = () => subscribers.forEach((fn) => fn(activeCount > 0));
+
+  return {
+    /**
+     * zone 활성/비활성 전환을 반영합니다. 동일 값이면 무시합니다.
+     * @param active 현재 zone 활성화 상태
+     * @param prev   직전 zone 활성화 상태
+     */
+    set(active: boolean, prev: boolean) {
+      if (active === prev) return;
+      // 단순히 "존 하나만 존재" 가정에 맞춘 토글
+      activeCount = active ? 1 : 0;
+      notify();
+    },
+
+    /**
+     * 활성 존 존재 여부(zoneActive)를 구독합니다.
+     * @param fn (isActiveZone: boolean) => void
+     * @returns 구독 해제 함수(unsubscribe)
+     */
+    subscribe(fn: (isActiveZone: boolean) => void) {
+      subscribers.add(fn);
+      fn(activeCount > 0); // 현재 상태 즉시 반영
+      return () => subscribers.delete(fn);
+    },
+  };
+})();
+
+type useMouseFollowerOptions<T extends HTMLElement = HTMLElement> = {
+  targetRef?: React.RefObject<T | null>;
+};
+
+/**
+ * `useMouseFollower` 훅은 DOM 요소를 마우스 포인터처럼 따라다니게 만들어주는 훅입니다.
+ *
+ * - 커스텀 요소를 생성해 마우스 포인터 대체용으로 활용할 수 있습니다.
+ * - `targetRef`가 있으면 해당 영역 안에서만 보이는 "존 커서", 없으면 "글로벌 커서"로 동작합니다.
+ * - 하나 이상의 존 커서가 활성화되면 글로벌 커서는 자동으로 숨겨집니다.
+ * - state 없이 ref + style만 갱신하여 리렌더링 없이 부드럽게 작동합니다.
+ *
+ * @template E 팔로워 요소 타입(기본: HTMLElement, 예: HTMLDivElement, HTMLSpanElement)
+ * @template T 타깃(존) 요소 타입(기본: HTMLElement, 예: HTMLDivElement)
+ *
+ * @param options
+ * @param options.targetRef 팔로워가 표시될 "존" 요소의 ref (없으면 글로벌 커서로 동작)
+ *
+ * @returns React.RefObject<E | null>
+ * - 커서로 사용할 요소에 붙일 ref
+ *
+ * @note 커서 엘리먼트에는 보통 다음 스타일을 권장합니다:
+ *  - position: fixed; pointer-events: none; will-change: transform;
+ *  - transform: translate3d(-9999px, -9999px, 0); // 초기 화면 밖
+ */
+export function useMouseFollower<E extends HTMLElement = HTMLElement, T extends HTMLElement = HTMLElement>({
+  targetRef = { current: null },
+}: useMouseFollowerOptions<T> = {}): React.RefObject<E | null> {
+  const cursorRef = useRef<E>(null);
+  const posRef = useRef({ x: -9999, y: -9999 });
+  const prevInsideRef = useRef(false);
+  const targetElRef = useRef<HTMLElement | null>(null);
+
+  // 1) targetRef 동기화
+  useEffect(() => {
+    targetElRef.current = targetRef.current ?? null;
+  }, [targetRef]);
+
+  // 2) 글로벌 커서: 활성 존 여부 구독 → opacity 토글
+  useEffect(() => {
+    if (targetElRef.current || !cursorRef.current) return;
+
+    const unsubscribe = cursorStore.subscribe((isActiveZone) => {
+      cursorRef.current.style.opacity = isActiveZone ? '0' : '1';
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  // 3) 좌표/가시성 갱신
+  const updateCursor = useCallback((x: number, y: number) => {
+    const el = cursorRef.current;
+    if (!el) return;
+
+    // 글로벌 커서
+    posRef.current = { x, y };
+    el.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+
+    // 존 커서
+    const targetEl = targetElRef.current;
+    if (targetEl) {
+      const rect = targetEl.getBoundingClientRect();
+      const inside = x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+      cursorStore.set(inside, prevInsideRef.current);
+      prevInsideRef.current = inside;
+      el.style.opacity = inside ? '1' : '0';
+    }
+  }, []);
+
+  // 4) 포인터 추적 (이벤트 등록)
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => updateCursor(e.clientX, e.clientY);
+
+    window.addEventListener('pointermove', onMove, { passive: true });
+    return () => {
+      window.removeEventListener('pointermove', onMove);
+      // 존 커서가 내부에서 사라질 때 상태 정리
+      if (targetElRef.current && prevInsideRef.current) {
+        cursorStore.set(false, true);
+        prevInsideRef.current = false;
+      }
+    };
+  }, [updateCursor]);
+
+  // 5) 뷰포트 변화 시 재판정(스크롤/리사이즈/타깃 스크롤)
+  useEffect(() => {
+    const targetEl = targetElRef.current;
+    if (!targetEl) return;
+
+    const recompute = () => updateCursor(posRef.current.x, posRef.current.y);
+
+    window.addEventListener('scroll', recompute, { passive: true });
+    window.addEventListener('resize', recompute);
+    targetEl.addEventListener('scroll', recompute, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', recompute);
+      window.removeEventListener('resize', recompute);
+      targetEl.removeEventListener('scroll', recompute);
+    };
+  }, [updateCursor]);
+
+  return cursorRef;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #73 

## 📝 훅 간단 사용 설명

`useMouseFollower`는 DOM 요소를 마우스 포인터처럼 따라다니게 만들어주는 커스텀 React Hook입니다.

- 커스텀 커서를 만들어 **기존 포인터(global cursor)를 대체**하거나, 특정 영역 안에서만 표시되는 **존 커서(zone cursor)** 를 구현할 수 있습니다.

- **존/글로벌 간 활성 상태를 자동으로 동기화** 해줍니다.
- 내부적으로는 전역 store를 두고, 하나 이상의 존 커서가 활성화되면 글로벌 커서는 자동으로 숨겨지는 방식으로 동작합니다.

- DOM 요소의 `transform: translate3d(x, y, 0)` 스타일을 직접 갱신하므로, 별도의 state 업데이트 없이 리렌더링 없이 부드럽게 움직입니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/a7965f25-a756-42ca-8374-dd90754db70c



