### PR TITLE
useDocumentTab 훅 / DocumentTab 컴포넌트 구현

### DIFF
--- a/docs/docs/components/DocumentTab.md
+++ b/docs/docs/components/DocumentTab.md
@@ -66,7 +66,7 @@ function App() {
 ### 라우트별로 다르게 적용하기 (React Router)
 
 ```tsx
-import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Link } from 'react-router';
 import { DocumentTab } from 'hookdle';
 
 const meta = [

--- a/docs/docs/components/DocumentTab.md
+++ b/docs/docs/components/DocumentTab.md
@@ -1,0 +1,126 @@
+# DocumentTab
+
+브라우저 **탭의 제목(title)** 과 **파비콘(favicon)** 을 라우트(pathname)에 맞춰 동적으로 변경하고, 컴포넌트 언마운트 시 원래 상태로 복구해주는 React 컴포넌트입니다.
+
+- 경로별로 다른 제목과 파비콘을 손쉽게 지정할 수 있습니다.
+- 라우팅 시 자동으로 탭 제목과 아이콘이 바뀌어 UX를 개선할 수 있습니다.
+- cleanup 시 원래 값으로 되돌려주므로, 다른 컴포넌트와 충돌하지 않습니다.
+
+---
+
+## 🔗 사용법
+
+```tsx
+<DocumentTab meta={meta} />
+```
+
+### props
+
+| 이름   | 타입     | 설명                           |
+| ------ | -------- | ------------------------------ |
+| `meta` | `Meta[]` | 경로별로 적용할 메타 정보 배열 |
+
+### `Meta` 구조
+
+| 필드      | 타입     | 설명                                             |
+| --------- | -------- | ------------------------------------------------ |
+| `path`    | `string` | 경로 패턴 (예: `'/'`, `'/about'`, `'/user/:id'`) |
+| `title`   | `string` | 브라우저 탭에 표시할 제목                        |
+| `favicon` | `string` | 브라우저 탭에 표시할 파비콘 이미지 URL           |
+
+---
+
+### 반환값
+
+없음 (`null` 렌더링)
+
+> 이 컴포넌트는 전역 document 상태를 제어하는 사이드 이펙트 전용입니다.
+
+---
+
+## ✅ 예시
+
+### 기본 예시
+
+```tsx
+import { DocumentTab } from 'componentdle';
+
+const meta = [
+  { path: '/', title: '홈 | MyApp', favicon: '/home.ico' },
+  { path: '/about', title: '소개 | MyApp', favicon: '/about.ico' },
+  { path: '/contact', title: '연락처 | MyApp', favicon: '/contact.ico' },
+];
+
+function App() {
+  return (
+    <>
+      <DocumentTab meta={meta} />
+      <div>앱 콘텐츠</div>
+    </>
+  );
+}
+```
+
+---
+
+### 라우트별로 다르게 적용하기 (React Router)
+
+```tsx
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
+import { DocumentTab } from 'hookdle';
+
+const meta = [
+  { path: '/', title: '홈 | MyApp', favicon: 'https://cdn-icons-png.flaticon.com/512/25/25694.png' },
+  { path: '/about', title: '소개 | MyApp', favicon: 'https://cdn-icons-png.flaticon.com/512/1077/1077114.png' },
+  { path: '/contact', title: '연락처 | MyApp', favicon: 'https://cdn-icons-png.flaticon.com/512/561/561127.png' },
+  { path: '/user/:id', title: '사용자 상세 | MyApp', favicon: '/user.ico' },
+];
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <DocumentTab meta={meta} />
+      <nav>
+        <Link to="/">홈</Link> | <Link to="/about">소개</Link> | <Link to="/contact">연락처</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<h1>홈</h1>} />
+        <Route path="/about" element={<h1>소개</h1>} />
+        <Route path="/contact" element={<h1>연락처</h1>} />
+        <Route path="/user/:id" element={<h1>사용자 상세</h1>} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+```
+
+---
+
+## 💡 만약 이 컴포넌트가 없다면?
+
+직접 `document.title`과 `<link rel="icon">`을 경로마다 관리해야 합니다.
+
+```tsx
+useEffect(() => {
+  const prevTitle = document.title;
+  document.title = '홈 | MyApp';
+
+  let link = document.querySelector<HTMLLinkElement>('link[rel*="icon"]');
+  const prevFavicon = link?.href;
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'icon';
+    document.head.appendChild(link);
+  }
+  link.href = 'home.ico';
+
+  return () => {
+    document.title = prevTitle;
+    if (prevFavicon && link) link.href = prevFavicon;
+  };
+}, []);
+```
+
+이처럼 직접 구현하면 **경로별 분기 처리, 초기값 저장/복구, favicon 태그 생성**까지 모두 수동으로 관리해야 합니다.
+
+`<DocumentTab />`을 사용하면 이 과정을 단순화하여 한 곳에서 깔끔하게 관리할 수 있습니다.

--- a/docs/docs/hooks/useDocumentTab.md
+++ b/docs/docs/hooks/useDocumentTab.md
@@ -1,0 +1,120 @@
+# useDocumentTab
+
+브라우저 **탭의 제목(title)** 과 **파비콘(favicon)** 을 동적으로 변경하고, 컴포넌트 언마운트 시 원래 상태로 복구해주는 커스텀 React 훅입니다.
+
+- 페이지 별로 다른 제목과 파비콘을 손쉽게 적용할 수 있습니다.
+- 라우팅 시 탭 제목과 아이콘을 함께 바꿔주어 UX를 개선할 수 있습니다.
+- cleanup 시 원래 값으로 되돌려주므로, 다른 컴포넌트와 충돌하지 않습니다.
+
+---
+
+## 🔗 사용법
+
+```tsx
+useDocumentTab(options);
+```
+
+### 매개변수
+
+| 이름      | 타입     | 설명                                                                   |
+| --------- | -------- | ---------------------------------------------------------------------- |
+| `options` | `object` | 설정 옵션 (`title`, `favicon`)                                         |
+| `title`   | `string` | 브라우저 탭에 표시할 제목                                              |
+| `favicon` | `string` | 브라우저 탭에 표시할 파비콘 이미지 URL (내부 경로 또는 외부 링크 가능) |
+
+---
+
+### 반환값
+
+없음 (`void`)
+
+> 이 훅은 단순히 전역 document 상태를 조작하기 때문에 반환값을 제공하지 않습니다.
+
+---
+
+## ✅ 예시
+
+### 기본 예시
+
+```tsx
+import { useDocumentTab } from 'hookdle';
+
+function HomePage() {
+  useDocumentTab({
+    title: '홈 | MyApp',
+    favicon: 'https://cdn-icons-png.flaticon.com/512/25/25694.png',
+  });
+
+  return <h1>홈</h1>;
+}
+```
+
+---
+
+### 라우트별로 다르게 적용하기 (React Router)
+
+```tsx
+import { BrowserRouter, Routes, Route, Link } from 'react-router';
+import { useDocumentTab } from 'hookdle';
+
+function Home() {
+  useDocumentTab({ title: '홈 | MyApp', favicon: 'https://cdn-icons-png.flaticon.com/512/25/25694.png' });
+  return <h1>홈</h1>;
+}
+
+function About() {
+  useDocumentTab({ title: '소개 | MyApp', favicon: 'https://cdn-icons-png.flaticon.com/512/1077/1077114.png' });
+  return <h1>소개</h1>;
+}
+
+function Contact() {
+  useDocumentTab({ title: '연락처 | MyApp', favicon: 'https://cdn-icons-png.flaticon.com/512/561/561127.png' });
+  return <h1>연락처</h1>;
+}
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <nav>
+        <Link to="/">홈</Link> | <Link to="/about">소개</Link> | <Link to="/contact">연락처</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/contact" element={<Contact />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+```
+
+---
+
+## 💡 만약 이 훅이 없다면?
+
+직접 `document.title`과 `<link rel="icon">`을 제어해야 합니다.
+
+```tsx
+useEffect(() => {
+  const prevTitle = document.title;
+  document.title = '홈 | MyApp';
+
+  let link = document.querySelector<HTMLLinkElement>('link[rel*="icon"]');
+  const prevFavicon = link?.href;
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'icon';
+    document.head.appendChild(link);
+  }
+  link.href = 'https://cdn-icons-png.flaticon.com/512/25/25694.png';
+
+  return () => {
+    document.title = prevTitle;
+    if (prevFavicon && link) link.href = prevFavicon;
+  };
+}, []);
+```
+
+이처럼 직접 구현하면 **초기값 저장/복구, favicon 태그 생성, cleanup 관리**까지 모두 수동으로 처리해야 합니다.
+
+`useDocumentTab`을 사용하면 이 과정을 간단하게 추상화할 수 있습니다.

--- a/packages/components/src/libs/DocumentTab.spec.tsx
+++ b/packages/components/src/libs/DocumentTab.spec.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { DocumentTab } from './DocumentTab';
+
+describe('DocumentTab', () => {
+  const meta = [
+    { path: '/', title: '홈', favicon: 'home.ico' },
+    { path: '/about', title: '소개', favicon: 'about.ico' },
+  ];
+
+  beforeEach(() => {
+    // 기본 문서 상태 초기화
+    document.title = 'Default Title';
+
+    // 기본 favicon 세팅
+    let link = document.querySelector<HTMLLinkElement>("link[rel*='icon']");
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'icon';
+      document.head.appendChild(link);
+    }
+    link.href = 'default.ico';
+
+    // URL 초기화
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('현재 경로("/")에 맞는 title을 설정해야 한다', () => {
+    render(<DocumentTab meta={meta} />);
+    expect(document.title).toBe('홈');
+  });
+
+  it('현재 경로("/")에 맞는 favicon을 설정해야 한다', () => {
+    render(<DocumentTab meta={meta} />);
+    const link = document.querySelector<HTMLLinkElement>('link[rel*="icon"]');
+    expect(link?.getAttribute('href')).toBe('home.ico');
+  });
+
+  it('경로를 "/about"으로 바꾸면 meta에 맞게 title이 바뀌어야 한다', () => {
+    window.history.pushState({}, '', '/about');
+    render(<DocumentTab meta={meta} />);
+    expect(document.title).toBe('소개');
+  });
+
+  it('컴포넌트 언마운트 시 title과 favicon이 원래대로 복구되어야 한다', () => {
+    const { unmount } = render(<DocumentTab meta={meta} />);
+    expect(document.title).toBe('홈');
+    const link = document.querySelector<HTMLLinkElement>('link[rel*="icon"]');
+    expect(link?.getAttribute('href')).toBe('home.ico');
+
+    unmount();
+    expect(document.title).toBe('Default Title');
+    expect(link?.getAttribute('href')).toBe('http://localhost/default.ico');
+  });
+});

--- a/packages/components/src/libs/DocumentTab.tsx
+++ b/packages/components/src/libs/DocumentTab.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+
+interface Meta {
+  path: string;
+  title?: string;
+  favicon?: string;
+}
+
+type DocumentTabProps = Meta[];
+
+/**
+ * `<DocumentTab />` 컴포넌트는 현재 URL 경로(pathname)를 감지하여
+ * 해당 경로에 맞는 **문서 제목(title)** 과 **파비콘(favicon)** 을 동적으로 설정합니다.
+ *
+ * - `meta` 배열에 정의된 path 패턴과 현재 `window.location.pathname`을 비교합니다.
+ * - 일치하는 항목이 있을 경우 `title`, `favicon`을 적용합니다.
+ * - 컴포넌트가 언마운트되면 원래 상태(제목, 파비콘)로 되돌립니다.
+ *
+ * @component
+ * @param {Object} props
+ * @param {Meta[]} props.meta - 경로별로 적용할 메타 정보 배열
+ *
+ */
+
+export function DocumentTab({ meta }: { meta: DocumentTabProps }) {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const current = meta.find((m) => matchRoute(m.path, pathname));
+    if (!current) return;
+
+    const { title, favicon } = current;
+
+    // Title
+    const prevTitle = document.title;
+    if (title) document.title = title;
+
+    // Favicon
+    let prevFavicon: string | null = null;
+    if (favicon) {
+      let link = document.querySelector<HTMLLinkElement>("link[rel*='icon']");
+      if (!link) {
+        link = document.createElement('link');
+        link.rel = 'icon';
+        document.head.appendChild(link);
+      }
+      prevFavicon = link.href;
+      link.href = favicon;
+    }
+
+    return () => {
+      if (title) document.title = prevTitle;
+      if (favicon && prevFavicon) {
+        const link = document.querySelector<HTMLLinkElement>("link[rel*='icon']");
+        if (link) link.href = prevFavicon;
+      }
+    };
+  }, [pathname, meta]);
+
+  return null;
+}
+
+// 지정 path랑 현재 pathname 맞추기
+const matchRoute = (pathPattern: string, pathname: string): boolean => {
+  const patternParts = pathPattern.split('/').filter(Boolean);
+  const pathParts = pathname.split('/').filter(Boolean);
+
+  if (patternParts.length !== pathParts.length) return false;
+
+  return patternParts.every((part, i) => {
+    if (part.startsWith(':')) return true;
+    return part === pathParts[i];
+  });
+};
+
+const usePathname = () => {
+  const [pathname, setPathname] = useState(() => window.location.pathname);
+
+  useEffect(() => {
+    const update = () => setPathname(window.location.pathname);
+    window.addEventListener('popstate', update);
+
+    // 기존의 pushState, replaceState 함수 저장
+    const pushState = history.pushState.bind(history);
+    const replaceState = history.replaceState.bind(history);
+
+    history.pushState = function (...args) {
+      pushState(...args);
+      update();
+    };
+
+    history.replaceState = function (...args) {
+      replaceState(...args);
+      update();
+    };
+
+    return () => {
+      window.removeEventListener('popstate', update);
+      history.pushState = pushState;
+      history.replaceState = replaceState;
+    };
+  }, []);
+
+  return pathname;
+};

--- a/packages/hooks/src/libs/useDocumentTab.spec.tsx
+++ b/packages/hooks/src/libs/useDocumentTab.spec.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react';
+import { useDocumentTab } from './useDocumentTab';
+
+describe('useDocumentTab', () => {
+  const TestComponent = ({ title, favicon }: { title?: string; favicon?: string }) => {
+    useDocumentTab({ title, favicon });
+    return <div>Test</div>;
+  };
+
+  beforeEach(() => {
+    // 기본 문서 상태 초기화
+    document.title = 'Default Title';
+
+    // 기존 favicon 태그 세팅
+    let link = document.querySelector<HTMLLinkElement>("link[rel*='icon']");
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'icon';
+      document.head.appendChild(link);
+    }
+    link.href = 'default.ico';
+  });
+
+  it('title 옵션을 주면 document.title이 바뀌어야 한다', () => {
+    render(<TestComponent title="New Title" />);
+    expect(document.title).toBe('New Title');
+  });
+
+  it('favicon 옵션을 주면 link[rel="icon"]이 바뀌어야 한다', () => {
+    render(<TestComponent favicon="https://example.com/new.ico" />);
+    const link = document.querySelector<HTMLLinkElement>("link[rel*='icon']");
+    expect(link?.href).toBe('https://example.com/new.ico');
+  });
+
+  it('cleanup 시 document.title이 원래대로 복구되어야 한다', () => {
+    const { unmount } = render(<TestComponent title="Temporary Title" />);
+    expect(document.title).toBe('Temporary Title');
+    unmount();
+    expect(document.title).toBe('Default Title');
+  });
+
+  it('cleanup 시 favicon이 원래대로 복구되어야 한다', () => {
+    const { unmount } = render(<TestComponent favicon="https://example.com/temp.ico" />);
+    const link = document.querySelector<HTMLLinkElement>("link[rel*='icon']");
+    expect(link?.href).toBe('https://example.com/temp.ico');
+
+    unmount();
+    expect(link?.href).toBe('http://localhost/default.ico');
+  });
+});

--- a/packages/hooks/src/libs/useDocumentTab.ts
+++ b/packages/hooks/src/libs/useDocumentTab.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+type UseDocumentTabOptions = {
+  title?: string;
+  favicon?: string;
+};
+
+/**
+ * `useDocumentTab` 훅은 브라우저 탭의 **문서 제목(title)** 과 **파비콘(favicon)** 을
+ * 동적으로 설정하고, 컴포넌트가 언마운트될 때 원래 상태로 되돌려주는 기능을 제공합니다.
+ *
+ *
+ * @param {Object} options - 탭 설정 옵션
+ * @param {string} [options.title] - 브라우저 탭에 표시할 제목
+ * @param {string} [options.favicon] - 브라우저 탭에 표시할 파비콘 이미지 URL
+ *
+ */
+export function useDocumentTab({ title, favicon }: UseDocumentTabOptions) {
+  // Title
+  useEffect(() => {
+    if (!title) return;
+    const prev = document.title;
+    document.title = title;
+    return () => {
+      document.title = prev;
+    };
+  }, [title]);
+
+  // Favicon
+  useEffect(() => {
+    if (!favicon) return;
+    let link = document.querySelector<HTMLLinkElement>("link[rel*='icon']");
+    if (!link) {
+      link = document.createElement('link');
+      link.rel = 'icon';
+      document.head.appendChild(link);
+    }
+    const prev = link.href;
+    link.href = favicon;
+    return () => {
+      link.href = prev;
+    };
+  }, [favicon]);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #97 

## 📝 훅 간단 사용 설명

> 브라우저 탭의 제목(title) 과 파비콘(favicon) 을 동적으로 변경하고, 컴포넌트 언마운트 시 원래 상태로 복구해주는 커스텀 React 훅입니다.

> 브라우저 탭의 제목(title) 과 파비콘(favicon) 을 동적으로 변경하고, 컴포넌트 언마운트 시 원래 상태로 복구해주는 커스텀 React 컴포넌트입니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/8da752ba-dfa6-4bd4-87f3-7a84d9187055

