### PR TITLE
useFileDrop 훅

### DIFF
--- a/docs/docs/hooks/useFileDrop.md
+++ b/docs/docs/hooks/useFileDrop.md
@@ -1,0 +1,73 @@
+# useFileDrop
+
+`useFileDrop`은 지정한 영역에 파일을 드래그 앤 드롭하여 업로드할 수 있도록 도와주는 커스텀 훅입니다.  
+파일 드롭 시 파일 목록과 드래그 상태를 관리하고, 확장자 제한, 최대 개수 제한, 에러 메시지 처리 기능도 제공합니다.
+
+## 🔗 사용법
+
+```ts
+const { ref, isOver, files, error, getDropZoneProps } = useFileDrop({
+  onDrop: (e, files) => console.log('dropped:', files),
+  onEnter: () => console.log('drag enter'),
+  onLeave: () => console.log('drag leave'),
+  disabled: false,
+  extensions: ['png', 'jpg'],
+  maxFiles: 5,
+});
+```
+
+### 매개변수 (options)
+
+| 이름         | 타입                                                          | 설명                                                      |
+| ------------ | ------------------------------------------------------------- | --------------------------------------------------------- |
+| `onDrop`     | `(e: React.DragEvent<HTMLDivElement>, files: File[]) => void` | 파일 드롭 시 실행되는 콜백 (optional)                     |
+| `onEnter`    | `() => void`                                                  | 드래그가 영역에 들어올 때 실행되는 콜백 (optional)        |
+| `onLeave`    | `() => void`                                                  | 드래그가 영역을 벗어날 때 실행되는 콜백 (optional)        |
+| `disabled`   | `boolean`                                                     | 드롭존 비활성화 여부 (optional)                           |
+| `extensions` | `string[]`                                                    | 허용할 파일 확장자 목록 (예: `['png', 'jpg']`) (optional) |
+| `maxFiles`   | `number`                                                      | 업로드 가능한 최대 파일 개수 (optional)                   |
+
+### 반환값
+
+`{ ref, isOver, files, getDropZoneProps, error }`
+
+| 이름               | 타입                                                     | 설명                                          |
+| ------------------ | -------------------------------------------------------- | --------------------------------------------- |
+| `ref`              | `RefObject<HTMLDivElement>`                              | 드롭존으로 사용할 DOM 요소에 연결할 ref       |
+| `isOver`           | `boolean`                                                | 현재 드래그 중인지 여부                       |
+| `files`            | `File[]`                                                 | 드롭된 파일들의 목록                          |
+| `getDropZoneProps` | `() => { onDragOver, onDrop, onDragEnter, onDragLeave }` | 드롭존에 필요한 이벤트 핸들러를 반환하는 함수 |
+| `error`            | `Error \| null`                                          | 제약 위반 시 발생한 에러 (optional)           |
+
+---
+
+## ✅ 예시
+
+```tsx
+import { useFileDrop } from './hooks/useFileDrop';
+
+function App() {
+  const { ref, isOver, files, error, getDropZoneProps } = useFileDrop({
+    extensions: ['png', 'jpg'],
+    maxFiles: 3,
+  });
+
+  return (
+    <div>
+      <div ref={ref} {...getDropZoneProps()}>
+        {isOver ? '여기에 파일을 놓으세요!' : '파일을 드래그 앤 드롭하세요'}
+      </div>
+
+      {error && <p style={{ color: 'red' }}>{error.message}</p>}
+
+      <ul>
+        {files.map((f) => (
+          <li key={`${f.name}-${f.lastModified}`}>{f.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default App;
+```

--- a/packages/hooks/src/libs/useFileDrop.spec.ts
+++ b/packages/hooks/src/libs/useFileDrop.spec.ts
@@ -1,0 +1,214 @@
+import { act, renderHook } from '@testing-library/react';
+import { useFileDrop } from './useFileDrop'; // 경로 맞게 수정
+
+function mkEvent() {
+  return {
+    preventDefault: jest.fn(),
+  } as unknown as React.DragEvent<HTMLDivElement>;
+}
+
+function mkFile(name: string, type = 'text/plain', content = 'hello') {
+  const blob = new Blob([content], { type });
+  return new File([blob], name, { type, lastModified: Date.now() });
+}
+
+// React.DragEvent 모킹: Array.from이 먹도록 files를 배열로 둔다
+function mkDropEvent(files: File[]) {
+  return {
+    preventDefault: jest.fn(),
+    dataTransfer: { files },
+  } as unknown as React.DragEvent<HTMLDivElement>;
+}
+
+describe('useFileDrop - 초기 상태', () => {
+  test('초기값들이 올바르게 설정된다', () => {
+    const { result } = renderHook(() => useFileDrop());
+
+    expect(result.current.ref.current).toBeNull();
+    expect(result.current.isOver).toBe(false);
+    expect(result.current.files).toEqual([]);
+    expect(result.current.error ?? null).toBeNull();
+
+    const props = result.current.getDropZoneProps();
+    expect(typeof props.onDragOver).toBe('function');
+    expect(typeof props.onDrop).toBe('function');
+    expect(typeof props.onDragEnter).toBe('function');
+    expect(typeof props.onDragLeave).toBe('function');
+  });
+});
+
+describe('useFileDrop - 드래그 상태', () => {
+  test('onDragEnter 호출 시 isOver=true 가 된다', () => {
+    const { result } = renderHook(() => useFileDrop());
+    const { onDragEnter } = result.current.getDropZoneProps();
+
+    const evt = mkEvent();
+    act(() => {
+      onDragEnter(evt);
+    });
+
+    expect(result.current.isOver).toBe(true);
+    expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  test('onDragLeave 호출 시 isOver=false 로 돌아간다', () => {
+    const { result } = renderHook(() => useFileDrop());
+    const { onDragEnter, onDragLeave } = result.current.getDropZoneProps();
+
+    const enterEvt = mkEvent();
+    const leaveEvt = mkEvent();
+
+    act(() => {
+      onDragEnter(enterEvt);
+    });
+    expect(result.current.isOver).toBe(true);
+
+    act(() => {
+      onDragLeave(leaveEvt);
+    });
+    expect(result.current.isOver).toBe(false);
+    expect(leaveEvt.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  test('onDragOver 는 기본 동작을 취소한다', () => {
+    const { result } = renderHook(() => useFileDrop());
+    const { onDragOver } = result.current.getDropZoneProps();
+
+    const evt = mkEvent();
+    act(() => {
+      onDragOver(evt);
+    });
+
+    expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+    expect(result.current.isOver).toBe(false);
+  });
+});
+
+describe('useFileDrop - 파일 드롭', () => {
+  test('onDrop 시 files 상태에 추가되고, onDrop 콜백이 호출된다', () => {
+    const f1 = mkFile('a.txt');
+    const f2 = mkFile('b.txt');
+
+    const onDropSpy = jest.fn();
+    const { result } = renderHook(() =>
+      useFileDrop({
+        onDrop: onDropSpy,
+      })
+    );
+
+    const { onDrop } = result.current.getDropZoneProps();
+
+    const evt = mkDropEvent([f1, f2]);
+
+    act(() => {
+      onDrop(evt);
+    });
+
+    // 상태에 누적되었는지
+    expect(result.current.files).toHaveLength(2);
+    expect(result.current.files.map((f) => f.name)).toEqual(['a.txt', 'b.txt']);
+
+    // preventDefault 호출
+    expect(evt.preventDefault).toHaveBeenCalledTimes(1);
+
+    // onDrop 콜백이 유효 파일 배열로 호출되었는지
+    expect(onDropSpy).toHaveBeenCalledTimes(1);
+    const [cbEvt, cbFiles] = onDropSpy.mock.calls[0];
+    expect(cbEvt).toBe(evt);
+    expect(cbFiles.map((f: File) => f.name)).toEqual(['a.txt', 'b.txt']);
+
+    // 드롭 이후 드래그 상태 초기화
+    expect(result.current.isOver).toBe(false);
+  });
+
+  test('여러 번 드롭하면 files가 누적된다', () => {
+    const f1 = mkFile('first.txt');
+    const f2 = mkFile('second.txt');
+    const f3 = mkFile('third.txt');
+
+    const { result } = renderHook(() => useFileDrop());
+    const { onDrop } = result.current.getDropZoneProps();
+
+    act(() => {
+      onDrop(mkDropEvent([f1]));
+    });
+    expect(result.current.files.map((f) => f.name)).toEqual(['first.txt']);
+
+    act(() => {
+      onDrop(mkDropEvent([f2, f3]));
+    });
+    expect(result.current.files.map((f) => f.name)).toEqual(['first.txt', 'second.txt', 'third.txt']);
+  });
+
+  test('disabled=true이면 drop이 무시된다', () => {
+    const f = mkFile('ignored.txt');
+
+    const { result } = renderHook(() => useFileDrop({ disabled: true }));
+    const { onDrop } = result.current.getDropZoneProps();
+
+    act(() => {
+      onDrop(mkDropEvent([f]));
+    });
+
+    expect(result.current.files).toHaveLength(0);
+  });
+});
+
+describe('useFileDrop - 확장자 필터링, 에러', () => {
+  test('extensions가 설정되면 허용 확장자만 files에 추가하고, 나머지는 에러를 남긴다', () => {
+    const f1 = mkFile('a.png', 'image/png');
+    const f2 = mkFile('b.jpg', 'image/jpeg');
+    const f3 = mkFile('c.txt', 'third.txt'); // 거절 대상
+
+    const { result } = renderHook(() => useFileDrop({ extensions: ['png', 'jpg'] }));
+    const { onDrop } = result.current.getDropZoneProps();
+
+    act(() => {
+      onDrop(mkDropEvent([f1, f2, f3]));
+    });
+
+    // 허용 파일만 쌓임
+    expect(result.current.files.map((f) => f.name)).toEqual(['a.png', 'b.jpg']);
+
+    // 에러 메시지 설정
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error!.message).toContain('허용되지 않은 파일 형식');
+    expect(result.current.error!.message).toContain('허용 확장자: png, jpg');
+  });
+
+  test('이후 유효한 파일만 드롭하면 에러가 해제된다', () => {
+    const bad = mkFile('bad.exe');
+    const good = mkFile('ok.jpg', 'image/jpeg');
+
+    const { result } = renderHook(() => useFileDrop({ extensions: ['png', 'jpg'] }));
+    const { onDrop } = result.current.getDropZoneProps();
+
+    // 잘못된 파일로 에러 발생
+    act(() => {
+      onDrop(mkDropEvent([bad]));
+    });
+    expect(result.current.error).not.toBeNull();
+
+    // 올바른 파일만 드롭 -> 에러 클리어
+    act(() => {
+      onDrop(mkDropEvent([good]));
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.files.map((f) => f.name)).toContain('ok.jpg');
+  });
+
+  test('extensions가 없으면 어떤 확장자도 거절하지 않는다(에러 없음)', () => {
+    const exe = mkFile('tool.exe');
+    const txt = mkFile('readme.txt', 'text/plain');
+
+    const { result } = renderHook(() => useFileDrop());
+    const { onDrop } = result.current.getDropZoneProps();
+
+    act(() => {
+      onDrop(mkDropEvent([exe, txt]));
+    });
+
+    expect(result.current.files.map((f) => f.name)).toEqual(['tool.exe', 'readme.txt']);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/hooks/src/libs/useFileDrop.ts
+++ b/packages/hooks/src/libs/useFileDrop.ts
@@ -1,0 +1,215 @@
+import { RefObject, useCallback, useMemo, useRef, useState } from 'react';
+
+/**
+ * useFileDrop 훅의 옵션입니다.
+ *
+ * @property {(e: React.DragEvent<HTMLDivElement>, currentFiles: File[]) => void} [onDrop]
+ *  - 파일이 드롭되어 최종 반영될 때 호출됩니다. (확장자/최대 개수 필터를 통과한 파일 배열 전달)
+ * @property {() => void} [onEnter]
+ *  - 드래그가 드롭존 영역에 처음 진입했을 때 호출됩니다. (파일 정보는 보안 정책상 이 시점에 없을 수 있음)
+ * @property {() => void} [onLeave]
+ *  - 드래그가 드롭존 영역을 완전히 벗어났을 때 호출됩니다.
+ * @property {boolean} [disabled]
+ *  - true면 모든 드래그/드롭 이벤트가 무시됩니다.
+ * @property {string[]} [extensions]
+ *  - 허용할 파일 확장자 목록입니다. 예: ['png', 'jpg'] (대소문자/앞의 점(.) 여부 무시)
+ * @property {number} [maxFiles]
+ *  - 누적 가능 최대 파일 개수입니다. 초과분은 잘라내고 에러가 설정됩니다.
+ */
+type UseFileDropOptions = {
+  onDrop?: (e: React.DragEvent<HTMLDivElement>, currentFiles: File[]) => void;
+  onEnter?: () => void;
+  onLeave?: () => void;
+  disabled?: boolean;
+  extensions?: string[];
+  maxFiles?: number;
+};
+
+/**
+ * useFileDrop 훅의 반환값입니다.
+ *
+ * @property {RefObject<HTMLDivElement>} ref
+ *  - 드롭존으로 사용할 DOM 요소에 연결할 ref입니다.
+ * @property {boolean} isOver
+ *  - 현재 포인터가 드롭존 위에 드래그 중인지 여부입니다.
+ * @property {File[]} files
+ *  - 드롭으로 누적된 파일 목록입니다.
+ * @property {() => { onDragOver: Function; onDrop: Function; onDragEnter: Function; onDragLeave: Function }} getDropZoneProps
+ *  - 드롭존에 바인딩할 드래그 이벤트 핸들러 묶음을 반환합니다.
+ * @property {Error | null | undefined} error
+ *  - 확장자 미스매치/최대 개수 초과 등 제약 위반 시 설정되는 에러입니다.
+ */
+type UseFileDropReturn = {
+  ref: RefObject<HTMLDivElement>;
+  isOver: boolean;
+  files: File[];
+  getDropZoneProps: () => {
+    onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+    onDrop: (e: React.DragEvent<HTMLDivElement>) => void;
+    onDragEnter: (e: React.DragEvent<HTMLDivElement>) => void;
+    onDragLeave: (e: React.DragEvent<HTMLDivElement>) => void;
+  };
+  error?: Error | null;
+};
+
+/**
+ * 지정한 영역에 파일을 드래그 앤 드롭해 `File[]`을 관리할 수 있게 해주는 훅입니다.
+ *
+ * - **파일 전용**: 텍스트/URL 등은 처리하지 않습니다.
+ * - `dragenter/dragover` 시점에는 보안 정책상 파일 정보에 접근할 수 없어도 정상입니다. (이때는 하이라이트만)
+ * - `drop` 시점에만 실제 파일 목록을 얻고, 확장자/최대 개수 제한을 적용합니다.
+ *
+ * @example
+ * const { ref, isOver, files, error, getDropZoneProps } = useFileDrop({
+ *   extensions: ['png', 'jpg'],
+ *   maxFiles: 5,
+ *   onDrop: (_e, fs) => console.log(fs),
+ * });
+ *
+ * return (
+ *   <div ref={ref} {...getDropZoneProps()}>
+ *     {isOver ? '놓으세요!' : '드래그 앤 드롭'}
+ *   </div>
+ * );
+ *
+ * @param {UseFileDropOptions} [options] 훅 동작을 제어하는 옵션
+ * @returns {UseFileDropReturn} 드롭존 ref/상태/핸들러 등
+ */
+export const useFileDrop = (options?: UseFileDropOptions): UseFileDropReturn => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [isOver, setIsOver] = useState(false);
+  const [files, setFiles] = useState<File[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+
+  const onDropRef = useRef(options?.onDrop);
+  const onEnterRef = useRef(options?.onEnter);
+  const onLeaveRef = useRef(options?.onLeave);
+  onDropRef.current = options?.onDrop;
+  onEnterRef.current = options?.onEnter;
+  onLeaveRef.current = options?.onLeave;
+
+  /**
+   * 허용 확장자 목록을 정규화합니다.
+   * - 대소문자 무시
+   * - 앞의 점(.) 유무 무시
+   * - 예: '.PNG' → 'png'
+   */
+  const allowedExt = useMemo(() => {
+    const list = options?.extensions ?? [];
+    return list.map((s) => (s.startsWith('.') ? s.slice(1) : s).toLowerCase());
+  }, [options?.extensions]);
+
+  /**
+   * 현재 드롭 이벤트에서 파일들을 추출합니다.
+   * - 파일 전용: dataTransfer.files 만 사용
+   */
+  const extractFiles = (e: React.DragEvent<HTMLDivElement>): File[] => Array.from(e.dataTransfer?.files ?? []);
+
+  /**
+   * 허용 확장자 목록이 있을 경우에만 필터링합니다.
+   */
+  const filterByExt = (arr: File[]): File[] => {
+    if (!allowedExt.length) return arr;
+    return arr.filter((f) => {
+      const ext = f.name.split('.').pop()?.toLowerCase() ?? '';
+      return allowedExt.includes(ext);
+    });
+  };
+
+  /**
+   * 드롭 가능 영역임을 알리기 위해 기본 동작을 막습니다.
+   * - 상태 변경은 하지 않습니다.
+   */
+  const onDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (options?.disabled) return;
+      e.preventDefault();
+    },
+    [options?.disabled]
+  );
+
+  /**
+   * 실제 파일이 드롭되었을 때 호출됩니다.
+   * - 파일을 추출 → 확장자 필터 적용 → 최대 개수 제한 적용 → 상태 갱신
+   * - 제약 위반이 있으면 `error`에 메시지를 설정합니다.
+   * - `onDrop` 콜백을 유효 파일 배열과 함께 호출합니다.
+   */
+  const onDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (options?.disabled) return;
+      e.preventDefault();
+
+      const all = extractFiles(e);
+      const valid = filterByExt(all);
+      const invalid = all.filter((f) => !valid.includes(f));
+
+      if (valid.length) {
+        setFiles((prev) => {
+          const next = [...prev, ...valid];
+          if (options?.maxFiles && next.length > options.maxFiles) {
+            setError(new Error(`최대 ${options.maxFiles}개 파일까지만 업로드할 수 있습니다.`));
+            return next.slice(0, options.maxFiles);
+          }
+          return next;
+        });
+      }
+      if (invalid.length) {
+        const allowed = allowedExt.join(', ');
+        setError(new Error(`허용되지 않은 파일 형식입니다. (허용 확장자: ${allowed})`));
+      } else {
+        setError(null);
+      }
+
+      onDropRef.current?.(e, valid);
+      setIsOver(false);
+    },
+    [options?.disabled, options?.maxFiles, allowedExt]
+  );
+
+  /**
+   * 드래그가 드롭존에 진입했을 때 호출됩니다.
+   * - 보안 정책상 이 시점에는 파일 정보가 없을 수 있습니다.
+   * - 하이라이트 용도로 `isOver=true`만 설정합니다.
+   */
+  const onDragEnter = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (options?.disabled) return;
+      e.preventDefault();
+
+      onEnterRef.current?.();
+      setIsOver(true);
+    },
+    [options?.disabled]
+  );
+
+  /**
+   * 드래그가 드롭존에서 완전히 벗어났을 때 호출됩니다.
+   * - 하이라이트 해제: `isOver=false`
+   */
+  const onDragLeave = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (options?.disabled) return;
+      e.preventDefault();
+      onLeaveRef.current?.();
+      setIsOver(false);
+    },
+    [options?.disabled]
+  );
+
+  /**
+   * 드롭존에 필요한 drag 이벤트 핸들러 묶음을 반환합니다.
+   * - 반환된 객체를 드롭존 DOM에 그대로 스프레드하세요.
+   *   예) <div ref={ref} {...getDropZoneProps()} />
+   */
+  const getDropZoneProps = useCallback(
+    () => ({
+      onDragOver,
+      onDrop,
+      onDragEnter,
+      onDragLeave,
+    }),
+    [onDragOver, onDrop, onDragEnter, onDragLeave]
+  );
+
+  return { ref, isOver, files, getDropZoneProps, error };
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #113 

## 📝 훅 간단 사용 설명

> `useFileDrop`은 사용자가 드래그 앤 드롭으로 파일을 업로드할 수 있도록 도와주는 커스텀 훅입니다.  
> 드래그 상태(`isOver`), 드롭된 파일 목록(`files`), 에러(`error`) 상태를 제공하며,  
> 확장자 제한(`extensions`), 파일 개수 제한(`maxFiles`), 드롭존 활성화/비활성화(`disabled`) 등을 옵션으로 제어할 수 있습니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/f281c295-0ef1-44d2-ab04-b459eabd1b90

