### PR TITLE
useGeolocation 훅

### DIFF
--- a/docs/docs/hooks/useGeolocation.md
+++ b/docs/docs/hooks/useGeolocation.md
@@ -1,0 +1,125 @@
+# useGeolocation
+
+`useGeolocation`은 브라우저의 Geolocation API를 사용하여 사용자의 현재 위치를 가져오거나 추적(watch) 하는 커스텀 React 훅입니다.
+
+위도(`latitude`), 경도(`longitude`) 등 좌표 정보를 손쉽게 얻을 수 있으며,
+옵션에 따라 한 번만 위치를 가져오거나(`getCurrentPosition`), 지속적으로 위치를 추적(`watchPosition`) 할 수 있습니다.
+
+## 🔗 사용법
+
+```tsx
+const { coords, loading, error } = useGeolocation(options);
+```
+
+### 매개변수
+
+| 이름                 | 타입      | 기본값     | 설명                                                                          |
+| -------------------- | --------- | ---------- | ----------------------------------------------------------------------------- |
+| `watch`              | `boolean` | `false`    | 위치 변화를 지속적으로 감지할지 여부<br>(`true`일 경우 `watchPosition` 사용)  |
+| `maximumAge`         | `number`  | `0`        | 캐시된 위치 정보를 허용할 최대 시간(ms 단위)<br>`0`이면 항상 최신 위치를 요청 |
+| `timeout`            | `number`  | `Infinity` | 위치 요청이 실패로 간주되기 전까지의 대기 시간(ms 단위)                       |
+| `enableHighAccuracy` | `boolean` | `false`    | 고정밀 모드 사용 여부<br>(GPS 등 고성능 센서 활용, 배터리 소모 증가 가능)     |
+
+### 반환값
+
+| 이름      | 타입                               | 설명                                                             |
+| --------- | ---------------------------------- | ---------------------------------------------------------------- |
+| `coords`  | `GeolocationCoordinates \| null`   | 사용자의 현재 좌표 정보 (`latitude`, `longitude`, `accuracy` 등) |
+| `loading` | `boolean`                          | 현재 위치 요청이 진행 중인지 여부                                |
+| `error`   | `GeolocationPositionError \| null` | 권한 거부, 타임아웃, 지원 불가 등의 에러 정보                    |
+
+## ✅ 예시
+
+### 1. 현재 위치 한 번만 가져오기
+
+```tsx
+import React, { useEffect } from 'react';
+import { useGeolocation } from './useGeolocation';
+
+function CurrentLocation() {
+  const { coords, loading, error } = useGeolocation();
+
+  useEffect(() => {
+    if (coords) {
+      console.log('현재 위치:', coords.latitude, coords.longitude);
+    }
+  }, [coords]);
+
+  if (loading) return <p>위치를 가져오는 중...</p>;
+  if (error) return <p>에러: {error.message}</p>;
+
+  return (
+    <div>
+      <p>위도: {coords?.latitude}</p>
+      <p>경도: {coords?.longitude}</p>
+    </div>
+  );
+}
+```
+
+### 2. 지속적으로 위치 추적하기 (예: 이동 중 사용자 위치 갱신)
+
+```tsx
+import React, { useEffect } from 'react';
+import { useGeolocation } from './useGeolocation';
+
+function MovingTracker() {
+  const { coords, error } = useGeolocation({
+    watch: true,
+    enableHighAccuracy: true,
+  });
+
+  useEffect(() => {
+    if (coords) {
+      console.log('위치가 변경되었습니다:', coords.latitude, coords.longitude);
+    }
+  }, [coords]);
+
+  if (error) return <p>에러: {error.message}</p>;
+
+  return (
+    <div>
+      <h3>실시간 위치 추적 중...</h3>
+      <p>위도: {coords?.latitude ?? '-'}</p>
+      <p>경도: {coords?.longitude ?? '-'}</p>
+    </div>
+  );
+}
+```
+
+### 3. 위치 권한 거부 처리
+
+```tsx
+import React from 'react';
+import { useGeolocation } from './useGeolocation';
+
+function PermissionCheck() {
+  const { error } = useGeolocation();
+
+  if (error?.code === 1) {
+    return <p>❌ 위치 접근이 거부되었습니다. 브라우저 설정에서 권한을 허용해주세요.</p>;
+  }
+
+  return <p>위치 정보 요청 중...</p>;
+}
+```
+
+## 📋 주의사항
+
+- navigator.geolocation은 HTTPS 환경에서만 작동합니다. (로컬 개발 시 localhost는 예외적으로 허용됩니다.)
+- 일부 데스크톱 브라우저에서는 위치 추적(watchPosition)이 느리거나 동작하지 않을 수 있습니다.
+- enableHighAccuracy 옵션을 활성화하면 정확도는 높아지지만, 배터리 소모가 증가할 수 있습니다.
+- maximumAge를 활용하면 동일한 위치 요청이 반복될 때 캐시된 데이터를 재사용할 수 있습니다.
+- error.code 값은 다음과 같습니다:
+  | 코드 | 상수명 | 설명 |
+  | --- | ---------------------- | ------------------ |
+  | `1` | `PERMISSION_DENIED` | 사용자가 위치 정보 접근을 거부함 |
+  | `2` | `POSITION_UNAVAILABLE` | 위치 정보를 가져올 수 없음 |
+  | `3` | `TIMEOUT` | 요청 제한 시간을 초과함 |
+
+## 🧩 관련 API
+
+- [MDN Web Docs – Geolocation API](https://developer.mozilla.org/ko/docs/Web/API/Geolocation_API)
+- [GeolocationPosition](https://developer.mozilla.org/ko/docs/Web/API/GeolocationPosition)
+- [GeolocationCoordinates](https://developer.mozilla.org/ko/docs/Web/API/GeolocationCoordinates)
+- [GeolocationPositionError](https://developer.mozilla.org/ko/docs/Web/API/GeolocationPositionError)

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookdle",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/hooks/src/libs/useGeolocation.spec.ts
+++ b/packages/hooks/src/libs/useGeolocation.spec.ts
@@ -1,0 +1,116 @@
+import { renderHook, act } from '@testing-library/react';
+import { useGeolocation } from './useGeolocation';
+
+// 공통 mock 좌표
+const mockCoords = {
+  latitude: 37.5665,
+  longitude: 126.978,
+  accuracy: 10,
+  altitude: null,
+  altitudeAccuracy: null,
+  heading: null,
+  speed: null,
+} as GeolocationCoordinates;
+
+describe('useGeolocation', () => {
+  let mockGetCurrentPosition: jest.Mock;
+  let mockWatchPosition: jest.Mock;
+  let mockClearWatch: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockGetCurrentPosition = jest.fn();
+    mockWatchPosition = jest.fn();
+    mockClearWatch = jest.fn();
+
+    // ✅ navigator.geolocation을 재정의 (readonly 속성 우회)
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: {
+        getCurrentPosition: mockGetCurrentPosition,
+        watchPosition: mockWatchPosition,
+        clearWatch: mockClearWatch,
+      },
+      writable: true,
+    });
+  });
+
+  it('브라우저에서 geolocation이 지원되지 않을 경우 에러를 반환한다', () => {
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: undefined,
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error?.message).toBe('Geolocation is not supported by this browser.');
+    expect(result.current.coords).toBeNull();
+  });
+
+  it('getCurrentPosition을 정상적으로 호출하고 위치를 설정한다', async () => {
+    const successCallback = jest.fn();
+    mockGetCurrentPosition.mockImplementation((success) => {
+      success({ coords: mockCoords });
+    });
+
+    const { result } = renderHook(() => useGeolocation());
+
+    expect(mockGetCurrentPosition).toHaveBeenCalledTimes(1);
+
+    // act로 상태 반영
+    await act(async () => {
+      successCallback();
+    });
+
+    expect(result.current.coords).toEqual(mockCoords);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('watchPosition 옵션이 true일 경우 watchPosition을 호출하고 clearWatch가 호출된다', () => {
+    const mockWatchId = 123;
+    mockWatchPosition.mockReturnValue(mockWatchId);
+
+    const { unmount } = renderHook(() => useGeolocation({ watch: true, enableHighAccuracy: true }));
+
+    expect(mockWatchPosition).toHaveBeenCalledTimes(1);
+    expect(mockWatchPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      expect.objectContaining({ enableHighAccuracy: true })
+    );
+
+    unmount();
+    expect(mockClearWatch).toHaveBeenCalledWith(mockWatchId);
+  });
+
+  it('getCurrentPosition 호출 시 에러가 발생하면 error 상태로 설정된다', async () => {
+    const mockError = { code: 1, message: 'User denied Geolocation' };
+    mockGetCurrentPosition.mockImplementation((_success, error) => error(mockError));
+
+    const { result } = renderHook(() => useGeolocation());
+
+    await act(async () => {});
+
+    expect(result.current.coords).toBeNull();
+    expect(result.current.error).toEqual(mockError);
+  });
+
+  it('watchPosition 콜백으로 위치가 업데이트되면 coords가 변경된다', async () => {
+    let successCallback: (pos: GeolocationPosition) => void = jest.fn();
+    mockWatchPosition.mockImplementation((success) => {
+      successCallback = success;
+      return 42;
+    });
+
+    const { result } = renderHook(() => useGeolocation({ watch: true }));
+
+    await act(async () => {
+      successCallback({ coords: mockCoords } as GeolocationPosition);
+    });
+
+    expect(result.current.coords).toEqual(mockCoords);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/packages/hooks/src/libs/useGeolocation.ts
+++ b/packages/hooks/src/libs/useGeolocation.ts
@@ -1,0 +1,56 @@
+import { useEffect, useMemo, useState } from 'react';
+
+interface UseGeolocationOptions {
+  watch?: boolean;
+  maximumAge?: number;
+  timeout?: number;
+  enableHighAccuracy?: boolean;
+}
+
+interface UseGeolocationReturns {
+  coords: GeolocationCoordinates | null; // 위도/경도 등 좌표 정보
+  loading: boolean; // 현재 위치 요청 중 여부
+  error: GeolocationPositionError | null; // 권한 거부, 타임아웃 등 에러
+}
+
+export function useGeolocation({
+  watch = false,
+  maximumAge = 0,
+  timeout = Infinity,
+  enableHighAccuracy = false,
+}: UseGeolocationOptions = {}): UseGeolocationReturns {
+  const [coords, setCoords] = useState<GeolocationCoordinates | null>(null);
+  const [error, setError] = useState<GeolocationPositionError | null>(null);
+  const loading = useMemo(() => coords === null && error === null, [coords, error]);
+
+  useEffect(() => {
+    if (!('geolocation' in navigator)) {
+      setError({ code: 0, message: 'Geolocation is not supported by this browser.' } as GeolocationPositionError);
+      return;
+    }
+
+    const onSuccess = (position: GeolocationPosition) => {
+      setCoords(position.coords);
+    };
+
+    const onError = (err: GeolocationPositionError) => {
+      setError(err);
+    };
+
+    const options = {
+      maximumAge,
+      timeout,
+      enableHighAccuracy,
+    };
+    console.log(options);
+
+    if (watch) {
+      const id = navigator.geolocation.watchPosition(onSuccess, onError, options);
+      return () => navigator.geolocation.clearWatch(id);
+    } else {
+      navigator.geolocation.getCurrentPosition(onSuccess, onError, options);
+    }
+  }, [enableHighAccuracy, maximumAge, timeout, watch]);
+
+  return { coords, loading, error };
+}

--- a/packages/hooks/src/libs/useGeolocation.ts
+++ b/packages/hooks/src/libs/useGeolocation.ts
@@ -13,6 +13,44 @@ interface UseGeolocationReturns {
   error: GeolocationPositionError | null; // 권한 거부, 타임아웃 등 에러
 }
 
+/**
+ * `useGeolocation` 훅은 사용자의 현재 위치 정보를 가져오거나 추적(watch)하는 React 훅입니다.
+ *
+ * - 브라우저의 Geolocation API를 사용하여 사용자의 위도, 경도 등의 위치 정보를 제공합니다.
+ * - `watch` 옵션을 활성화하면 사용자의 위치가 변경될 때마다 자동으로 갱신됩니다.
+ * - `getCurrentPosition`과 `watchPosition`을 상황에 따라 선택적으로 사용하며,
+ *   권한 거부, 타임아웃 등의 에러 상태도 함께 반환합니다.
+ * - `enableHighAccuracy`, `timeout`, `maximumAge` 등의 옵션을 통해 위치 요청의 정밀도 및 성능을 제어할 수 있습니다.
+ *
+ * @param {Object} [options] - 위치 요청 시 사용할 설정 옵션
+ * @param {boolean} [options.watch=false] - 위치 변화를 지속적으로 감지할지 여부 (`true` 시 `watchPosition` 사용)
+ * @param {number} [options.maximumAge=0] - 캐시된 위치 정보를 허용할 최대 시간(ms 단위)
+ * @param {number} [options.timeout=Infinity] - 위치 요청이 실패로 간주되기 전까지의 대기 시간(ms 단위)
+ * @param {boolean} [options.enableHighAccuracy=false] - 고정밀 모드 사용 여부 (GPS 등 고성능 센서 활용)
+ *
+ * @returns {Object} - 위치 정보 및 상태를 담은 객체
+ * @returns {GeolocationCoordinates | null} return.coords - 사용자의 위도, 경도 등 위치 좌표 정보
+ * @returns {boolean} return.loading - 현재 위치 요청이 진행 중인지 여부 (`true`: 로딩 중)
+ * @returns {GeolocationPositionError | null} return.error - 위치 요청 중 발생한 에러 정보
+ *
+ * @example
+ * ```tsx
+ * // 단 한 번 현재 위치 가져오기
+ * const { coords, loading, error } = useGeolocation();
+ *
+ * // 지속적으로 위치 추적 (예: 지도 이동 감지)
+ * const { coords } = useGeolocation({ watch: true, enableHighAccuracy: true });
+ *
+ * useEffect(() => {
+ *   if (coords) {
+ *     console.log('현재 위치:', coords.latitude, coords.longitude);
+ *   }
+ *   if (error) {
+ *     console.error('위치 정보를 가져오지 못했습니다:', error.message);
+ *   }
+ * }, [coords, error]);
+ * ```
+ */
 export function useGeolocation({
   watch = false,
   maximumAge = 0,

--- a/packages/hooks/src/libs/useGeolocation.ts
+++ b/packages/hooks/src/libs/useGeolocation.ts
@@ -62,7 +62,7 @@ export function useGeolocation({
   const loading = useMemo(() => coords === null && error === null, [coords, error]);
 
   useEffect(() => {
-    if (!('geolocation' in navigator)) {
+    if (!('geolocation' in navigator) || !navigator.geolocation) {
       setError({ code: 0, message: 'Geolocation is not supported by this browser.' } as GeolocationPositionError);
       return;
     }
@@ -80,7 +80,6 @@ export function useGeolocation({
       timeout,
       enableHighAccuracy,
     };
-    console.log(options);
 
     if (watch) {
       const id = navigator.geolocation.watchPosition(onSuccess, onError, options);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호
https://github.com/woowacourse-study/2025-fe-hookponent/issues/111

## 📝 훅 간단 사용 설명

> 어떤 훅인지 간단하게 설명해주세요! (docs 내용 기반)

`useGeolocation`은 브라우저의 Geolocation API를 사용하여 사용자의 현재 위치를 가져오거나 추적(watch) 하는 커스텀 React 훅입니다.

위도(`latitude`), 경도(`longitude`) 등 좌표 정보를 손쉽게 얻을 수 있으며,
옵션에 따라 한 번만 위치를 가져오거나(`getCurrentPosition`), 지속적으로 위치를 추적(`watchPosition`) 할 수 있습니다.

### 스크린샷 (선택)


https://github.com/user-attachments/assets/bdeb0197-1a4f-4f1a-abbb-18af258b9392


