### PR TITLE
feat: useEventDelegation 훅

### DIFF
--- a/docs/docs/hooks/useEventDelegation.md
+++ b/docs/docs/hooks/useEventDelegation.md
@@ -1,0 +1,166 @@
+# useEventDelegation
+
+이벤트 위임(Event Delegation) 패턴으로 **대량의 하위 요소에 대한 이벤트 처리를 최적화**하는 커스텀 React Hook입니다.
+
+- 부모 컨테이너에 **하나의 핸들러만 등록**하고 하위 요소 이벤트를 효율적으로 처리
+- `data-id` 속성으로 **요소와 데이터를 자동 매핑**
+- **커스텀 selector/idAttribute** 지원으로 유연한 매칭
+- 내장된 `stopPropagation`/`preventDefault` 옵션
+- **callbackRef 패턴**으로 불필요한 핸들러 재생성 방지
+
+---
+
+## 🔗 사용법
+
+```tsx
+const handler = useEventDelegation(dataList, callback, options?);
+```
+
+---
+
+## 📥 매개변수
+
+| 이름       | 타입                | 설명                                   |
+| ---------- | ------------------- | -------------------------------------- |
+| `dataList` | `readonly T[]`      | 이벤트와 연결할 데이터 배열            |
+| `callback` | `EventCallback<T>`  | 이벤트 발생 시 실행될 콜백 함수        |
+| `options`  | `DelegationOptions` | 선택값 / 매칭 방식 및 이벤트 제어 설정 |
+
+### 🔧 `callback` 시그니처
+
+```tsx
+type EventCallback<T> = (event: React.SyntheticEvent, data: T, element: HTMLElement) => void;
+```
+
+### 🔧 `options` 구조
+
+| 필드              | 타입       | 설명                                          |
+| ----------------- | ---------- | --------------------------------------------- |
+| `selector`        | `string?`  | 매칭할 CSS selector (기본: `[idAttribute]`)   |
+| `idAttribute`     | `string?`  | 요소에서 id를 읽을 속성명 (기본: `'data-id'`) |
+| `stopPropagation` | `boolean?` | 이벤트 버블링 중단 여부 (기본: `false`)       |
+| `preventDefault`  | `boolean?` | 브라우저 기본 동작 방지 여부 (기본: `false`)  |
+
+---
+
+## 🔁 반환값
+
+| 타입                                    | 설명                                      |
+| --------------------------------------- | ----------------------------------------- |
+| `(event: React.SyntheticEvent) => void` | 부모 컨테이너에 등록할 이벤트 핸들러 함수 |
+
+---
+
+## ✅ 예시
+
+### 1) 기본 예시 (data-id 매핑)
+
+- 가장 일반적인 사용법. `data-id` 속성으로 요소와 데이터를 매핑합니다.
+
+```tsx
+import { useEventDelegation } from 'hookdle';
+
+const items = [
+  { id: 1, name: 'Apple', price: 100 },
+  { id: 2, name: 'Banana', price: 200 },
+  { id: 3, name: 'Cherry', price: 300 },
+];
+
+export default function ItemList() {
+  const handleItemClick = useEventDelegation(items, (event, item, element) => {
+    console.log(`Clicked: ${item.name} (${item.price}원)`);
+    element.classList.add('clicked');
+  });
+
+  return (
+    <div onClick={handleItemClick} className="item-container">
+      {items.map((item) => (
+        <button key={item.id} data-id={item.id} className="item-button">
+          {item.name} - {item.price}원
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+### 2) 커스텀 속성 (idAttribute)
+
+- `data-id` 대신 다른 속성으로 매핑하고 싶을 때 사용합니다.
+
+```tsx
+const tabs = [
+  { id: 'home', label: '홈', content: 'Home content' },
+  { id: 'about', label: '소개', content: 'About content' },
+];
+
+function TabNavigation() {
+  const handleTabClick = useEventDelegation(
+    tabs,
+    (e, tab) => {
+      setActiveTab(tab.id);
+    },
+    {
+      idAttribute: 'data-tab-id',
+    }
+  );
+
+  return (
+    <nav onClick={handleTabClick}>
+      {tabs.map((tab) => (
+        <button key={tab.id} data-tab-id={tab.id}>
+          {tab.label}
+        </button>
+      ))}
+    </nav>
+  );
+}
+```
+
+### 3) 고급 selector 및 이벤트 제어
+
+- 더 구체적인 매칭과 이벤트 동작 제어가 필요할 때 사용합니다.
+
+```tsx
+const menuItems = [
+  { id: 1, name: 'Edit', action: 'edit' },
+  { id: 2, name: 'Delete', action: 'delete' },
+];
+
+function ContextMenu() {
+  const handleMenuClick = useEventDelegation(
+    menuItems,
+    (e, item, el) => {
+      console.log(`Action: ${item.action}`);
+      // 메뉴 닫기
+      closeContextMenu();
+    },
+    {
+      selector: 'li button.menu-action',
+      stopPropagation: true,
+      preventDefault: true,
+    }
+  );
+
+  return (
+    <ul onClick={handleMenuClick} className="context-menu">
+      {menuItems.map((item) => (
+        <li key={item.id}>
+          <button className="menu-action" data-id={item.id}>
+            {item.name}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+---
+
+## 🧩 팁
+
+- **타입 안전성**: `const items = [...] as const` 사용으로 id 타입을 더 엄격하게 관리
+- **options 최적화**: `useMemo`로 options 객체를 안정화하여 핸들러 재생성 방지
+- **성능**: 대량 리스트(100+ 아이템)에서 개별 이벤트 리스너 대비 월등한 성능
+- **접근성**: `role`, `aria-*` 속성과 함께 사용하여 키보드 내비게이션 지원

--- a/packages/hooks/src/libs/useEventDelegation.spec.ts
+++ b/packages/hooks/src/libs/useEventDelegation.spec.ts
@@ -1,0 +1,82 @@
+import { renderHook } from '@testing-library/react';
+import { useEventDelegation } from './useEventDelegation';
+
+describe('useEventDelegation', () => {
+  it('기본 data-id를 가진 자식 요소 클릭 시 콜백을 호출한다', () => {
+    const items = [
+      { id: 1, name: 'one' },
+      { id: 2, name: 'two' },
+    ];
+    const mockCallback = jest.fn();
+
+    const { result } = renderHook(() => useEventDelegation(items, mockCallback));
+
+    const handler = result.current;
+
+    document.body.addEventListener('click', handler as unknown as EventListener);
+    const btn = document.createElement('button');
+    btn.setAttribute('data-id', '2');
+    document.body.appendChild(btn);
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockCallback.mock.calls[0][1]).toEqual(items[1]);
+    expect(mockCallback.mock.calls[0][2]).toBe(btn);
+
+    btn.remove();
+    document.body.removeEventListener('click', handler as unknown as EventListener);
+  });
+
+  it('커스텀 idAttribute를 지원한다', () => {
+    const items = [{ id: 'a', value: 10 }];
+    const mockCallback = jest.fn();
+
+    const { result } = renderHook(() => useEventDelegation(items, mockCallback, { idAttribute: 'data-key' }));
+
+    const handler = result.current;
+    document.body.addEventListener('click', handler as unknown as EventListener);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('data-key', 'a');
+    document.body.appendChild(btn);
+
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(mockCallback.mock.calls[0][1]).toEqual(items[0]);
+
+    btn.remove();
+    document.body.removeEventListener('click', handler as unknown as EventListener);
+  });
+
+  it('stopPropagation 및 preventDefault 옵션을 준수한다', () => {
+    const items = [{ id: 1 }];
+    const mockCallback = jest.fn();
+
+    const { result } = renderHook(() =>
+      useEventDelegation(items, mockCallback, { stopPropagation: true, preventDefault: true })
+    );
+
+    const handler = result.current;
+    document.body.addEventListener('click', handler as unknown as EventListener);
+
+    const btn = document.createElement('button');
+    btn.setAttribute('data-id', '1');
+    document.body.appendChild(btn);
+
+    const stopSpy = jest.spyOn(Event.prototype, 'stopPropagation');
+    const preventSpy = jest.spyOn(Event.prototype, 'preventDefault');
+
+    btn.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    expect(mockCallback).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalled();
+    expect(preventSpy).toHaveBeenCalled();
+
+    stopSpy.mockRestore();
+    preventSpy.mockRestore();
+
+    btn.remove();
+    document.body.removeEventListener('click', handler as unknown as EventListener);
+  });
+});

--- a/packages/hooks/src/libs/useEventDelegation.ts
+++ b/packages/hooks/src/libs/useEventDelegation.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+
+type ItemWithId = { id: string | number };
+
+interface OptionsType {
+  selector?: string;
+  idAttribute?: string;
+  stopPropagation?: boolean;
+  preventDefault?: boolean;
+}
+
+/**
+ * 이벤트 위임(Event Delegation)을 사용하여 대량의 요소에 대한 이벤트 처리를 최적화하는 React 훅입니다.
+ *
+ * 이 훅은 다음을 제공합니다:
+ * - `dataList`의 각 항목을 id로 매핑한 내부 Map을 생성하여 빠르게 조회합니다.
+ * - 부모 컨테이너에 하나의 이벤트 핸들러를 등록하고, 발생한 이벤트의 타겟이 `selector` 또는
+ *   `idAttribute`와 일치하는 하위 요소일 때만 콜백을 호출합니다.
+ * - 최초 마운트 시에는 이벤트를 무시하고(업데이트 시에만 실행) 최신 콜백을 사용하기 위해 내부적으로
+ *   `callbackRef`를 사용합니다.
+ *
+ * @template T - 각 항목이 `id` 프로퍼티를 가진 타입
+ * @param dataList - 이벤트와 연결될 데이터 배열 (각 항목은 `id: string | number` 를 가져야 함)
+ * @param callback - 이벤트가 발생했을 때 실행될 콜백 함수. 시그니처는 `(event, data, el)` 입니다.
+ * @param options - 추가 옵션
+ * @param options.selector - 요소를 찾을 CSS selector (지정하면 이 selector를 사용)
+ * @param options.idAttribute - 요소에서 id를 읽어올 속성명. 기본값 `'data-id'`.
+ *                                  (selector가 주어지지 않으면 `[${options.idAttribute}]`가 사용됩니다)
+ * @param options.stopPropagation - true면 이벤트에 대해 stopPropagation()을 호출합니다.
+ * @param options.preventDefault - true면 이벤트에 대해 preventDefault()를 호출합니다.
+ * @returns React SyntheticEvent를 인자로 받는 핸들러 함수 (예: onClick)
+ *
+ * @example
+ * ```tsx
+ * const items = [{ id: 1, name: 'Item 1' }, { id: 2, name: 'Item 2' }];
+ *
+ * // 기본 사용: data-id 속성을 사용
+ * const handleItemClick = useEventDelegation(items, (e, item) => {
+ *   console.log(item.name);
+ * });
+ *
+ * // 커스텀 속성 사용 예시
+ * const handleItemClick2 = useEventDelegation(items, (e, item) => {
+ *   console.log(item.name);
+ * }, { idAttribute: 'data-key' });
+ *
+ * return (
+ *   <div onClick={handleItemClick}>
+ *     {items.map(item => (
+ *       <button key={item.id} data-id={item.id}>{item.name}</button>
+ *     ))}
+ *   </div>
+ * );
+ * ```
+ *
+ * @remarks
+ * - 이 훅은 내부적으로 `callbackRef`를 사용하여 최신 콜백을 참조하므로, 외부에서 콜백이 바뀌어도
+ *   핸들러를 재생성하지 않습니다.
+ */
+export function useEventDelegation<T extends ItemWithId>(
+  dataList: readonly T[],
+  callback: (event: React.SyntheticEvent, data: T, el: HTMLElement) => void,
+  options?: OptionsType
+): (event: React.SyntheticEvent) => void {
+  const callbackRef = useRef(callback);
+  const { selector, idAttribute = 'data-id', stopPropagation = false, preventDefault = false } = options || {};
+
+  const effectiveSelector = selector ?? `[${idAttribute}]`;
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  const map = useMemo(
+    () => dataList.reduce((acc, data) => acc.set(String(data.id), data), new Map<string, T>()),
+    [dataList]
+  );
+
+  const handler = useCallback(
+    (event: React.SyntheticEvent) => {
+      const target = event.target;
+
+      if (!(target instanceof Element)) return;
+
+      const candidate = target.matches?.(effectiveSelector) ? target : target.closest?.(effectiveSelector);
+      if (!candidate || !(candidate instanceof Element)) return;
+
+      const matchedElement = candidate as Element;
+      if (!(matchedElement instanceof HTMLElement)) return;
+
+      const key = matchedElement.getAttribute(idAttribute);
+      if (!key) return;
+
+      const data = map.get(key);
+      if (!data) return;
+
+      if (stopPropagation) event.stopPropagation?.();
+      if (preventDefault) event.preventDefault?.();
+
+      callbackRef.current?.(event, data, matchedElement);
+    },
+    [effectiveSelector, idAttribute, map, stopPropagation, preventDefault]
+  );
+
+  return handler;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #112 

## 📝 훅 간단 사용 설명

> 어떤 훅인지 간단하게 설명해주세요! (docs 내용 기반)

### 🎯 한 줄 요약
리스트의 각 아이템에 개별 이벤트 리스너 대신, 부모에 하나만 등록해서 성능을 최적화하는 훅

### 💡 핵심
- 문제: 100개 버튼 → 100개 이벤트 리스너 (비효율)
- 해결: 부모 1개에만 리스너 등록 → data-id로 클릭된 아이템 찾기
- 결과: 메모리 절약 + 성능 향상

대량의 상호작용 요소(버튼, 카드 등)가 있을 때 필수인 최적화 훅입니다.

### 스크린샷 (선택)
![chrome-capture-2025-09-29 (1)](https://github.com/user-attachments/assets/58a7498a-5d7e-4b21-a781-db61afb33838)
